### PR TITLE
Updated to latest version of libraries and added Markdown Extra

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,13 +2,45 @@
 This product includes code and libraries developed by third parties, which are governed by different licenses.  These components, and their licenses, are listed below.
 
 == PHP MARKDOWN ==
-Copyright (c) 2004-2007 Michel Fortin http://www.michelf.com/projects/php-markdown/
-Original Markdown Copyright (c) 2004-2006 John Gruber  http://daringfireball.net/projects/markdown/
-PHP Markdown is available under a BSD-style open source license; See BSD for a copy of the BSD license.
+Copyright (c) 2004-2013 Michel Fortin 
+<http://michelf.ca/>  
+All rights reserved.
 
-== PHP SMARTYPANTS ==
-Copyright (c) 2004-2005 Michel Fortin http://www.michelf.com/projects/php-smartypants/
-Original SmartyPants Copyright (c) 2003-2004 John Gruber http://daringfireball.net/projects/smartypants/
-PHP SmartyPants is available under a BSD-style open source license; See BSD for a copy of the BSD license.
+=== Based on Markdown ===  
+Copyright (c) 2003-2006 John Gruber   
+<http://daringfireball.net/>   
+All rights reserved.
 
-This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
+== PHP MARKDOWN & EXTRA ==  
+Copyright (c) 2004-2013 Michel Fortin  
+<http://michelf.ca/>  
+All rights reserved.
+
+=== Based on Markdown ===  
+Copyright (c) 2003-2006 John Gruber   
+<http://daringfireball.net/>   
+All rights reserved.
+
+== PHP SMARTYPANTS ==  
+Copyright (c) 2005-2013 Michel Fortin  
+<http://michelf.ca/>  
+All rights reserved.
+
+=== Original SmartyPants ===  
+Copyright (c) 2003-2004 John Gruber  
+<http://daringfireball.net/>  
+All rights reserved.   
+PHP SmartyPants is available under a BSD-style open source license; See
+BSD for a copy of the BSD license.
+
+This software is provided by the copyright holders and contributors "as
+is" and any express or implied warranties, including, but not limited
+to, the implied warranties of merchantability and fitness for a
+particular purpose are disclaimed. In no event shall the copyright owner
+or contributors be liable for any direct, indirect, incidental, special,
+exemplary, or consequential damages (including, but not limited to,
+procurement of substitute goods or services; loss of use, data, or
+profits; or business interruption) however caused and on any theory of
+liability, whether in contract, strict liability, or tort (including
+negligence or otherwise) arising in any way out of the use of this
+software, even if advised of the possibility of such damage.

--- a/habarimarkdown.plugin.php
+++ b/habarimarkdown.plugin.php
@@ -45,7 +45,8 @@ class HabariMarkdown extends Plugin
 	public function action_plugin_ui( $plugin_id, $action )
 	{
 		if ( $this->plugin_id()==$plugin_id && $action=='Configure' ) {
-			$form = new FormUI( strtolower(get_class( $this ) ) );
+            $form = new FormUI( strtolower(get_class( $this ) ) );
+            $form->append( 'checkbox', 'enable MarkdownExtra', 'option:habarimarkdown__extra', _t( 'Use Markdown Extra') );
 			$form->append( 'checkbox', 'enable SmartyPants', 'option:habarimarkdown__smarty', _t( 'Enable SmartyPants' ) );
 			$form->append( 'submit', 'save', _t( 'Save' ) );
 			$form->out();
@@ -60,9 +61,16 @@ class HabariMarkdown extends Plugin
 	 */
 	public function action_atom_add_post( $feed_entry, $post )
 	{
-		if ( !function_exists( 'Markdown' ) ) {
-			require_once('markdown.php');
-		}
+        if ( !function_exists( 'Markdown' ) ) {
+            $use_md_extra = Options::get( 'habarimarkdown__extra', false );
+            if ( $use_md_extra ) {
+                $md_filename = 'markdown-extra.php';
+            }
+            else {
+                $md_filename = 'markdown.php';
+            }
+            require_once( $md_filename );
+        }
 		
 		// Only apply changes to unauthenticated viewers.  This allows markdown to be used in atompub clients too.
 		if ( ! User::identify()->loggedin ) {
@@ -84,9 +92,16 @@ class MarkdownFormat extends Format
 	public static function markdown( $content )
 	{
 
-		if ( !function_exists( 'Markdown' ) ) {
-			require_once('markdown.php');
-		}
+        if ( !function_exists( 'Markdown' ) ) {
+            $use_md_extra = Options::get( 'habarimarkdown__extra', false );
+            if ( $use_md_extra ) {
+                $md_filename = 'markdown-extra.php';
+            }
+            else {
+                $md_filename = 'markdown.php';
+            }
+            require_once( $md_filename );
+        }
 
 		$smarty_enabled = Options::get( 'habarimarkdown__smarty', false );
 		if ( $smarty_enabled ) {
@@ -107,9 +122,16 @@ class MarkdownFormat extends Format
 	public static function comment_safe_markdown( $content )
 	{
 
-		if ( !function_exists( 'Markdown' ) ) {
-			require_once('markdown.php');
-		}
+        if ( !function_exists( 'Markdown' ) ) {
+            $use_md_extra = Options::get( 'habarimarkdown__extra', false );
+            if ( $use_md_extra ) {
+                $md_filename = 'markdown-extra.php';
+            }
+            else {
+                $md_filename = 'markdown.php';
+            }
+            require_once( $md_filename );
+        }
 
 		$html = '';
 		$smarty_enabled = Options::get( 'habarimarkdown__smarty', false );

--- a/habarimarkdown.plugin.xml
+++ b/habarimarkdown.plugin.xml
@@ -2,14 +2,14 @@
 <pluggable type="plugin">
 	<name>Habari Markdown</name>
 	<author url="http://habariproject.org/">The Habari Community</author>
-	<version>0.4.6</version>
+	<version>0.5</version>
 	<url>http://habariproject.org/</url>
 	<description><![CDATA[Enables John Gruber's Markdown syntax for posts.]]></description>
 	<license url="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0 and BSD (see NOTICE)</license>
-	<copyright>2010</copyright>
+	<copyright>2013</copyright>
 	<guid>5b530155-d8d3-47e7-9b3b-0694cf968516</guid>
 	<help>
-		<value><![CDATA[Full details on John Gruber's Markdown syntax can be found at <a href="http://daringfireball.net/projects/markdown/" target="_blank">http://daringfireball.net/projects/markdown/</a>.]]></value>
+        <value><![CDATA[Full details on John Gruber's Markdown syntax can be found at <a href="http://daringfireball.net/projects/markdown/" target="_blank">http://daringfireball.net/projects/markdown/</a>. Full details on Michel Fortin's Markdown Extra syntax can be found at <a href="http://michelf.ca/projects/php-markdown/extra/" target="_blank">http://michelf.ca/projects/php-markdown/extra</a>]]></value>
 	</help>
 </pluggable> 
  

--- a/markdown-extra.php
+++ b/markdown-extra.php
@@ -1,8 +1,8 @@
 <?php
 #
-# Markdown  -  A text-to-HTML conversion tool for web writers
+# Markdown Extra  -  A text-to-HTML conversion tool for web writers
 #
-# PHP Markdown  
+# PHP Markdown & Extra  
 # Copyright (c) 2004-2013 Michel Fortin  
 # <http://michelf.ca/projects/php-markdown/>
 #
@@ -13,6 +13,7 @@
 
 
 define( 'MARKDOWN_VERSION',  "1.0.1p" ); # Sun 13 Jan 2013
+define( 'MARKDOWNEXTRA_VERSION',  "1.2.6" ); # Sun 13 Jan 2013
 
 
 #
@@ -25,10 +26,25 @@ define( 'MARKDOWN_VERSION',  "1.0.1p" ); # Sun 13 Jan 2013
 # Define the width of a tab for code blocks.
 @define( 'MARKDOWN_TAB_WIDTH',     4 );
 
+# Optional title attribute for footnote links and backlinks.
+@define( 'MARKDOWN_FN_LINK_TITLE',         "" );
+@define( 'MARKDOWN_FN_BACKLINK_TITLE',     "" );
+
+# Optional class attribute for footnote links and backlinks.
+@define( 'MARKDOWN_FN_LINK_CLASS',         "" );
+@define( 'MARKDOWN_FN_BACKLINK_CLASS',     "" );
+
+# Optional class prefix for fenced code block.
+@define( 'MARKDOWN_CODE_CLASS_PREFIX',     "" );
+
+# Class attribute for code blocks goes on the `code` tag;
+# setting this to true will put attributes on the `pre` tag instead.
+@define( 'MARKDOWN_CODE_ATTR_ON_PRE',   false );
+
 
 ### Standard Function Interface ###
 
-@define( 'MARKDOWN_PARSER_CLASS',  'Markdown_Parser' );
+@define( 'MARKDOWN_PARSER_CLASS',  'MarkdownExtra_Parser' );
 
 function Markdown($text) {
 #
@@ -1550,16 +1566,1291 @@ class Markdown_Parser {
 
 }
 
+
+#
+# Markdown Extra Parser Class
+#
+
+class MarkdownExtra_Parser extends Markdown_Parser {
+
+	### Configuration Variables ###
+
+	# Prefix for footnote ids.
+	var $fn_id_prefix = "";
+	
+	# Optional title attribute for footnote links and backlinks.
+	var $fn_link_title = MARKDOWN_FN_LINK_TITLE;
+	var $fn_backlink_title = MARKDOWN_FN_BACKLINK_TITLE;
+	
+	# Optional class attribute for footnote links and backlinks.
+	var $fn_link_class = MARKDOWN_FN_LINK_CLASS;
+	var $fn_backlink_class = MARKDOWN_FN_BACKLINK_CLASS;
+
+	# Optional class prefix for fenced code block.
+	var $code_class_prefix = MARKDOWN_CODE_CLASS_PREFIX;
+	# Class attribute for code blocks goes on the `code` tag;
+	# setting this to true will put attributes on the `pre` tag instead.
+	var $code_attr_on_pre = MARKDOWN_CODE_ATTR_ON_PRE;
+	
+	# Predefined abbreviations.
+	var $predef_abbr = array();
+
+
+	### Parser Implementation ###
+
+	function MarkdownExtra_Parser() {
+	#
+	# Constructor function. Initialize the parser object.
+	#
+		# Add extra escapable characters before parent constructor 
+		# initialize the table.
+		$this->escape_chars .= ':|';
+		
+		# Insert extra document, block, and span transformations. 
+		# Parent constructor will do the sorting.
+		$this->document_gamut += array(
+			"doFencedCodeBlocks" => 5,
+			"stripFootnotes"     => 15,
+			"stripAbbreviations" => 25,
+			"appendFootnotes"    => 50,
+			);
+		$this->block_gamut += array(
+			"doFencedCodeBlocks" => 5,
+			"doTables"           => 15,
+			"doDefLists"         => 45,
+			);
+		$this->span_gamut += array(
+			"doFootnotes"        => 5,
+			"doAbbreviations"    => 70,
+			);
+		
+		parent::Markdown_Parser();
+	}
+	
+	
+	# Extra variables used during extra transformations.
+	var $footnotes = array();
+	var $footnotes_ordered = array();
+	var $footnotes_ref_count = array();
+	var $footnotes_numbers = array();
+	var $abbr_desciptions = array();
+	var $abbr_word_re = '';
+	
+	# Give the current footnote number.
+	var $footnote_counter = 1;
+	
+	
+	function setup() {
+	#
+	# Setting up Extra-specific variables.
+	#
+		parent::setup();
+		
+		$this->footnotes = array();
+		$this->footnotes_ordered = array();
+		$this->footnotes_ref_count = array();
+		$this->footnotes_numbers = array();
+		$this->abbr_desciptions = array();
+		$this->abbr_word_re = '';
+		$this->footnote_counter = 1;
+		
+		foreach ($this->predef_abbr as $abbr_word => $abbr_desc) {
+			if ($this->abbr_word_re)
+				$this->abbr_word_re .= '|';
+			$this->abbr_word_re .= preg_quote($abbr_word);
+			$this->abbr_desciptions[$abbr_word] = trim($abbr_desc);
+		}
+	}
+	
+	function teardown() {
+	#
+	# Clearing Extra-specific variables.
+	#
+		$this->footnotes = array();
+		$this->footnotes_ordered = array();
+		$this->footnotes_ref_count = array();
+		$this->footnotes_numbers = array();
+		$this->abbr_desciptions = array();
+		$this->abbr_word_re = '';
+		
+		parent::teardown();
+	}
+	
+	
+	### Extra Attribute Parser ###
+
+	# Expression to use to catch attributes (includes the braces)
+	var $id_class_attr_catch_re = '\{((?:[ ]*[#.][-_:a-zA-Z0-9]+){1,})[ ]*\}';
+	# Expression to use when parsing in a context when no capture is desired
+	var $id_class_attr_nocatch_re = '\{(?:[ ]*[#.][-_:a-zA-Z0-9]+){1,}[ ]*\}';
+
+	function doExtraAttributes($tag_name, $attr) {
+	#
+	# Parse attributes caught by the $this->id_class_attr_catch_re expression
+	# and return the HTML-formatted list of attributes.
+	#
+	# Currently supported attributes are .class and #id.
+	#
+		if (empty($attr)) return "";
+		
+		# Split on components
+		preg_match_all("/[.#][-_:a-zA-Z0-9]+/", $attr, $matches);
+		$elements = $matches[0];
+
+		# handle classes and ids (only first id taken into account)
+		$classes = array();
+		$id = false;
+		foreach ($elements as $element) {
+			if ($element{0} == '.') {
+				$classes[] = substr($element, 1);
+			} else if ($element{0} == '#') {
+				if ($id === false) $id = substr($element, 1);
+			}
+		}
+
+		# compose attributes as string
+		$attr_str = "";
+		if (!empty($id)) {
+			$attr_str .= ' id="'.$id.'"';
+		}
+		if (!empty($classes)) {
+			$attr_str .= ' class="'.implode(" ", $classes).'"';
+		}
+		return $attr_str;
+	}
+
+
+	### HTML Block Parser ###
+	
+	# Tags that are always treated as block tags:
+	var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|section|nav|aside|hgroup|header|footer|figcaption';
+						   
+	# Tags treated as block tags only if the opening tag is alone on its line:
+	var $context_block_tags_re = 'script|noscript|ins|del|iframe|object|source|track|param|math|svg|canvas|audio|video';
+	
+	# Tags where markdown="1" default to span mode:
+	var $contain_span_tags_re = 'p|h[1-6]|li|dd|dt|td|th|legend|address';
+	
+	# Tags which must not have their contents modified, no matter where 
+	# they appear:
+	var $clean_tags_re = 'script|math|svg';
+	
+	# Tags that do not need to be closed.
+	var $auto_close_tags_re = 'hr|img|param|source|track';
+	
+
+	function hashHTMLBlocks($text) {
+	#
+	# Hashify HTML Blocks and "clean tags".
+	#
+	# We only want to do this for block-level HTML tags, such as headers,
+	# lists, and tables. That's because we still want to wrap <p>s around
+	# "paragraphs" that are wrapped in non-block-level tags, such as anchors,
+	# phrase emphasis, and spans. The list of tags we're looking for is
+	# hard-coded.
+	#
+	# This works by calling _HashHTMLBlocks_InMarkdown, which then calls
+	# _HashHTMLBlocks_InHTML when it encounter block tags. When the markdown="1" 
+	# attribute is found within a tag, _HashHTMLBlocks_InHTML calls back
+	#  _HashHTMLBlocks_InMarkdown to handle the Markdown syntax within the tag.
+	# These two functions are calling each other. It's recursive!
+	#
+		if ($this->no_markup)  return $text;
+
+		#
+		# Call the HTML-in-Markdown hasher.
+		#
+		list($text, ) = $this->_hashHTMLBlocks_inMarkdown($text);
+		
+		return $text;
+	}
+	function _hashHTMLBlocks_inMarkdown($text, $indent = 0, 
+										$enclosing_tag_re = '', $span = false)
+	{
+	#
+	# Parse markdown text, calling _HashHTMLBlocks_InHTML for block tags.
+	#
+	# *   $indent is the number of space to be ignored when checking for code 
+	#     blocks. This is important because if we don't take the indent into 
+	#     account, something like this (which looks right) won't work as expected:
+	#
+	#     <div>
+	#         <div markdown="1">
+	#         Hello World.  <-- Is this a Markdown code block or text?
+	#         </div>  <-- Is this a Markdown code block or a real tag?
+	#     <div>
+	#
+	#     If you don't like this, just don't indent the tag on which
+	#     you apply the markdown="1" attribute.
+	#
+	# *   If $enclosing_tag_re is not empty, stops at the first unmatched closing 
+	#     tag with that name. Nested tags supported.
+	#
+	# *   If $span is true, text inside must treated as span. So any double 
+	#     newline will be replaced by a single newline so that it does not create 
+	#     paragraphs.
+	#
+	# Returns an array of that form: ( processed text , remaining text )
+	#
+		if ($text === '') return array('', '');
+
+		# Regex to check for the presense of newlines around a block tag.
+		$newline_before_re = '/(?:^\n?|\n\n)*$/';
+		$newline_after_re = 
+			'{
+				^						# Start of text following the tag.
+				(?>[ ]*<!--.*?-->)?		# Optional comment.
+				[ ]*\n					# Must be followed by newline.
+			}xs';
+		
+		# Regex to match any tag.
+		$block_tag_re =
+			'{
+				(					# $2: Capture whole tag.
+					</?					# Any opening or closing tag.
+						(?>				# Tag name.
+							'.$this->block_tags_re.'			|
+							'.$this->context_block_tags_re.'	|
+							'.$this->clean_tags_re.'        	|
+							(?!\s)'.$enclosing_tag_re.'
+						)
+						(?:
+							(?=[\s"\'/a-zA-Z0-9])	# Allowed characters after tag name.
+							(?>
+								".*?"		|	# Double quotes (can contain `>`)
+								\'.*?\'   	|	# Single quotes (can contain `>`)
+								.+?				# Anything but quotes and `>`.
+							)*?
+						)?
+					>					# End of tag.
+				|
+					<!--    .*?     -->	# HTML Comment
+				|
+					<\?.*?\?> | <%.*?%>	# Processing instruction
+				|
+					<!\[CDATA\[.*?\]\]>	# CData Block
+				|
+					# Code span marker
+					`+
+				'. ( !$span ? ' # If not in span.
+				|
+					# Indented code block
+					(?: ^[ ]*\n | ^ | \n[ ]*\n )
+					[ ]{'.($indent+4).'}[^\n]* \n
+					(?>
+						(?: [ ]{'.($indent+4).'}[^\n]* | [ ]* ) \n
+					)*
+				|
+					# Fenced code block marker
+					(?<= ^ | \n )
+					[ ]{0,'.($indent+3).'}~{3,}
+									[ ]*
+					(?:
+						[.]?[-_:a-zA-Z0-9]+ # standalone class name
+					|
+						'.$this->id_class_attr_nocatch_re.' # extra attributes
+					)?
+					[ ]*
+					\n
+				' : '' ). ' # End (if not is span).
+				)
+			}xs';
+
+		
+		$depth = 0;		# Current depth inside the tag tree.
+		$parsed = "";	# Parsed text that will be returned.
+
+		#
+		# Loop through every tag until we find the closing tag of the parent
+		# or loop until reaching the end of text if no parent tag specified.
+		#
+		do {
+			#
+			# Split the text using the first $tag_match pattern found.
+			# Text before  pattern will be first in the array, text after
+			# pattern will be at the end, and between will be any catches made 
+			# by the pattern.
+			#
+			$parts = preg_split($block_tag_re, $text, 2, 
+								PREG_SPLIT_DELIM_CAPTURE);
+			
+			# If in Markdown span mode, add a empty-string span-level hash 
+			# after each newline to prevent triggering any block element.
+			if ($span) {
+				$void = $this->hashPart("", ':');
+				$newline = "$void\n";
+				$parts[0] = $void . str_replace("\n", $newline, $parts[0]) . $void;
+			}
+			
+			$parsed .= $parts[0]; # Text before current tag.
+			
+			# If end of $text has been reached. Stop loop.
+			if (count($parts) < 3) {
+				$text = "";
+				break;
+			}
+			
+			$tag  = $parts[1]; # Tag to handle.
+			$text = $parts[2]; # Remaining text after current tag.
+			$tag_re = preg_quote($tag); # For use in a regular expression.
+			
+			#
+			# Check for: Code span marker
+			#
+			if ($tag{0} == "`") {
+				# Find corresponding end marker.
+				$tag_re = preg_quote($tag);
+				if (preg_match('{^(?>.+?|\n(?!\n))*?(?<!`)'.$tag_re.'(?!`)}',
+					$text, $matches))
+				{
+					# End marker found: pass text unchanged until marker.
+					$parsed .= $tag . $matches[0];
+					$text = substr($text, strlen($matches[0]));
+				}
+				else {
+					# Unmatched marker: just skip it.
+					$parsed .= $tag;
+				}
+			}
+			#
+			# Check for: Fenced code block marker.
+			#
+			else if (preg_match('{^\n?([ ]{0,'.($indent+3).'})(~+)}', $tag, $capture)) {
+				# Fenced code block marker: find matching end marker.
+				$fence_indent = strlen($capture[1]); # use captured indent in re
+				$fence_re = $capture[2]; # use captured fence in re
+				if (preg_match('{^(?>.*\n)*?[ ]{'.($fence_indent).'}'.$fence_re.'[ ]*(?:\n|$)}', $text,
+					$matches)) 
+				{
+					# End marker found: pass text unchanged until marker.
+					$parsed .= $tag . $matches[0];
+					$text = substr($text, strlen($matches[0]));
+				}
+				else {
+					# No end marker: just skip it.
+					$parsed .= $tag;
+				}
+			}
+			#
+			# Check for: Indented code block.
+			#
+			else if ($tag{0} == "\n" || $tag{0} == " ") {
+				# Indented code block: pass it unchanged, will be handled 
+				# later.
+				$parsed .= $tag;
+			}
+			#
+			# Check for: Opening Block level tag or
+			#            Opening Context Block tag (like ins and del) 
+			#               used as a block tag (tag is alone on it's line).
+			#
+			else if (preg_match('{^<(?:'.$this->block_tags_re.')\b}', $tag) ||
+				(	preg_match('{^<(?:'.$this->context_block_tags_re.')\b}', $tag) &&
+					preg_match($newline_before_re, $parsed) &&
+					preg_match($newline_after_re, $text)	)
+				)
+			{
+				# Need to parse tag and following text using the HTML parser.
+				list($block_text, $text) = 
+					$this->_hashHTMLBlocks_inHTML($tag . $text, "hashBlock", true);
+				
+				# Make sure it stays outside of any paragraph by adding newlines.
+				$parsed .= "\n\n$block_text\n\n";
+			}
+			#
+			# Check for: Clean tag (like script, math)
+			#            HTML Comments, processing instructions.
+			#
+			else if (preg_match('{^<(?:'.$this->clean_tags_re.')\b}', $tag) ||
+				$tag{1} == '!' || $tag{1} == '?')
+			{
+				# Need to parse tag and following text using the HTML parser.
+				# (don't check for markdown attribute)
+				list($block_text, $text) = 
+					$this->_hashHTMLBlocks_inHTML($tag . $text, "hashClean", false);
+				
+				$parsed .= $block_text;
+			}
+			#
+			# Check for: Tag with same name as enclosing tag.
+			#
+			else if ($enclosing_tag_re !== '' &&
+				# Same name as enclosing tag.
+				preg_match('{^</?(?:'.$enclosing_tag_re.')\b}', $tag))
+			{
+				#
+				# Increase/decrease nested tag count.
+				#
+				if ($tag{1} == '/')						$depth--;
+				else if ($tag{strlen($tag)-2} != '/')	$depth++;
+
+				if ($depth < 0) {
+					#
+					# Going out of parent element. Clean up and break so we
+					# return to the calling function.
+					#
+					$text = $tag . $text;
+					break;
+				}
+				
+				$parsed .= $tag;
+			}
+			else {
+				$parsed .= $tag;
+			}
+		} while ($depth >= 0);
+		
+		return array($parsed, $text);
+	}
+	function _hashHTMLBlocks_inHTML($text, $hash_method, $md_attr) {
+	#
+	# Parse HTML, calling _HashHTMLBlocks_InMarkdown for block tags.
+	#
+	# *   Calls $hash_method to convert any blocks.
+	# *   Stops when the first opening tag closes.
+	# *   $md_attr indicate if the use of the `markdown="1"` attribute is allowed.
+	#     (it is not inside clean tags)
+	#
+	# Returns an array of that form: ( processed text , remaining text )
+	#
+		if ($text === '') return array('', '');
+		
+		# Regex to match `markdown` attribute inside of a tag.
+		$markdown_attr_re = '
+			{
+				\s*			# Eat whitespace before the `markdown` attribute
+				markdown
+				\s*=\s*
+				(?>
+					(["\'])		# $1: quote delimiter		
+					(.*?)		# $2: attribute value
+					\1			# matching delimiter	
+				|
+					([^\s>]*)	# $3: unquoted attribute value
+				)
+				()				# $4: make $3 always defined (avoid warnings)
+			}xs';
+		
+		# Regex to match any tag.
+		$tag_re = '{
+				(					# $2: Capture whole tag.
+					</?					# Any opening or closing tag.
+						[\w:$]+			# Tag name.
+						(?:
+							(?=[\s"\'/a-zA-Z0-9])	# Allowed characters after tag name.
+							(?>
+								".*?"		|	# Double quotes (can contain `>`)
+								\'.*?\'   	|	# Single quotes (can contain `>`)
+								.+?				# Anything but quotes and `>`.
+							)*?
+						)?
+					>					# End of tag.
+				|
+					<!--    .*?     -->	# HTML Comment
+				|
+					<\?.*?\?> | <%.*?%>	# Processing instruction
+				|
+					<!\[CDATA\[.*?\]\]>	# CData Block
+				)
+			}xs';
+		
+		$original_text = $text;		# Save original text in case of faliure.
+		
+		$depth		= 0;	# Current depth inside the tag tree.
+		$block_text	= "";	# Temporary text holder for current text.
+		$parsed		= "";	# Parsed text that will be returned.
+
+		#
+		# Get the name of the starting tag.
+		# (This pattern makes $base_tag_name_re safe without quoting.)
+		#
+		if (preg_match('/^<([\w:$]*)\b/', $text, $matches))
+			$base_tag_name_re = $matches[1];
+
+		#
+		# Loop through every tag until we find the corresponding closing tag.
+		#
+		do {
+			#
+			# Split the text using the first $tag_match pattern found.
+			# Text before  pattern will be first in the array, text after
+			# pattern will be at the end, and between will be any catches made 
+			# by the pattern.
+			#
+			$parts = preg_split($tag_re, $text, 2, PREG_SPLIT_DELIM_CAPTURE);
+			
+			if (count($parts) < 3) {
+				#
+				# End of $text reached with unbalenced tag(s).
+				# In that case, we return original text unchanged and pass the
+				# first character as filtered to prevent an infinite loop in the 
+				# parent function.
+				#
+				return array($original_text{0}, substr($original_text, 1));
+			}
+			
+			$block_text .= $parts[0]; # Text before current tag.
+			$tag         = $parts[1]; # Tag to handle.
+			$text        = $parts[2]; # Remaining text after current tag.
+			
+			#
+			# Check for: Auto-close tag (like <hr/>)
+			#			 Comments and Processing Instructions.
+			#
+			if (preg_match('{^</?(?:'.$this->auto_close_tags_re.')\b}', $tag) ||
+				$tag{1} == '!' || $tag{1} == '?')
+			{
+				# Just add the tag to the block as if it was text.
+				$block_text .= $tag;
+			}
+			else {
+				#
+				# Increase/decrease nested tag count. Only do so if
+				# the tag's name match base tag's.
+				#
+				if (preg_match('{^</?'.$base_tag_name_re.'\b}', $tag)) {
+					if ($tag{1} == '/')						$depth--;
+					else if ($tag{strlen($tag)-2} != '/')	$depth++;
+				}
+				
+				#
+				# Check for `markdown="1"` attribute and handle it.
+				#
+				if ($md_attr && 
+					preg_match($markdown_attr_re, $tag, $attr_m) &&
+					preg_match('/^1|block|span$/', $attr_m[2] . $attr_m[3]))
+				{
+					# Remove `markdown` attribute from opening tag.
+					$tag = preg_replace($markdown_attr_re, '', $tag);
+					
+					# Check if text inside this tag must be parsed in span mode.
+					$this->mode = $attr_m[2] . $attr_m[3];
+					$span_mode = $this->mode == 'span' || $this->mode != 'block' &&
+						preg_match('{^<(?:'.$this->contain_span_tags_re.')\b}', $tag);
+					
+					# Calculate indent before tag.
+					if (preg_match('/(?:^|\n)( *?)(?! ).*?$/', $block_text, $matches)) {
+						$strlen = $this->utf8_strlen;
+						$indent = $strlen($matches[1], 'UTF-8');
+					} else {
+						$indent = 0;
+					}
+					
+					# End preceding block with this tag.
+					$block_text .= $tag;
+					$parsed .= $this->$hash_method($block_text);
+					
+					# Get enclosing tag name for the ParseMarkdown function.
+					# (This pattern makes $tag_name_re safe without quoting.)
+					preg_match('/^<([\w:$]*)\b/', $tag, $matches);
+					$tag_name_re = $matches[1];
+					
+					# Parse the content using the HTML-in-Markdown parser.
+					list ($block_text, $text)
+						= $this->_hashHTMLBlocks_inMarkdown($text, $indent, 
+							$tag_name_re, $span_mode);
+					
+					# Outdent markdown text.
+					if ($indent > 0) {
+						$block_text = preg_replace("/^[ ]{1,$indent}/m", "", 
+													$block_text);
+					}
+					
+					# Append tag content to parsed text.
+					if (!$span_mode)	$parsed .= "\n\n$block_text\n\n";
+					else				$parsed .= "$block_text";
+					
+					# Start over with a new block.
+					$block_text = "";
+				}
+				else $block_text .= $tag;
+			}
+			
+		} while ($depth > 0);
+		
+		#
+		# Hash last block text that wasn't processed inside the loop.
+		#
+		$parsed .= $this->$hash_method($block_text);
+		
+		return array($parsed, $text);
+	}
+
+
+	function hashClean($text) {
+	#
+	# Called whenever a tag must be hashed when a function inserts a "clean" tag
+	# in $text, it passes through this function and is automaticaly escaped, 
+	# blocking invalid nested overlap.
+	#
+		return $this->hashPart($text, 'C');
+	}
+
+
+	function doHeaders($text) {
+	#
+	# Redefined to add id and class attribute support.
+	#
+		# Setext-style headers:
+		#	  Header 1  {#header1}
+		#	  ========
+		#  
+		#	  Header 2  {#header2 .class1 .class2}
+		#	  --------
+		#
+		$text = preg_replace_callback(
+			'{
+				(^.+?)								# $1: Header text
+				(?:[ ]+ '.$this->id_class_attr_catch_re.' )?	 # $3 = id/class attributes
+				[ ]*\n(=+|-+)[ ]*\n+				# $3: Header footer
+			}mx',
+			array(&$this, '_doHeaders_callback_setext'), $text);
+
+		# atx-style headers:
+		#	# Header 1        {#header1}
+		#	## Header 2       {#header2}
+		#	## Header 2 with closing hashes ##  {#header3.class1.class2}
+		#	...
+		#	###### Header 6   {.class2}
+		#
+		$text = preg_replace_callback('{
+				^(\#{1,6})	# $1 = string of #\'s
+				[ ]*
+				(.+?)		# $2 = Header text
+				[ ]*
+				\#*			# optional closing #\'s (not counted)
+				(?:[ ]+ '.$this->id_class_attr_catch_re.' )?	 # $3 = id/class attributes
+				[ ]*
+				\n+
+			}xm',
+			array(&$this, '_doHeaders_callback_atx'), $text);
+
+		return $text;
+	}
+	function _doHeaders_callback_setext($matches) {
+		if ($matches[3] == '-' && preg_match('{^- }', $matches[1]))
+			return $matches[0];
+		$level = $matches[3]{0} == '=' ? 1 : 2;
+		$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[2]);
+		$block = "<h$level$attr>".$this->runSpanGamut($matches[1])."</h$level>";
+		return "\n" . $this->hashBlock($block) . "\n\n";
+	}
+	function _doHeaders_callback_atx($matches) {
+		$level = strlen($matches[1]);
+		$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[3]);
+		$block = "<h$level$attr>".$this->runSpanGamut($matches[2])."</h$level>";
+		return "\n" . $this->hashBlock($block) . "\n\n";
+	}
+
+
+	function doTables($text) {
+	#
+	# Form HTML tables.
+	#
+		$less_than_tab = $this->tab_width - 1;
+		#
+		# Find tables with leading pipe.
+		#
+		#	| Header 1 | Header 2
+		#	| -------- | --------
+		#	| Cell 1   | Cell 2
+		#	| Cell 3   | Cell 4
+		#
+		$text = preg_replace_callback('
+			{
+				^							# Start of a line
+				[ ]{0,'.$less_than_tab.'}	# Allowed whitespace.
+				[|]							# Optional leading pipe (present)
+				(.+) \n						# $1: Header row (at least one pipe)
+				
+				[ ]{0,'.$less_than_tab.'}	# Allowed whitespace.
+				[|] ([ ]*[-:]+[-| :]*) \n	# $2: Header underline
+				
+				(							# $3: Cells
+					(?>
+						[ ]*				# Allowed whitespace.
+						[|] .* \n			# Row content.
+					)*
+				)
+				(?=\n|\Z)					# Stop at final double newline.
+			}xm',
+			array(&$this, '_doTable_leadingPipe_callback'), $text);
+		
+		#
+		# Find tables without leading pipe.
+		#
+		#	Header 1 | Header 2
+		#	-------- | --------
+		#	Cell 1   | Cell 2
+		#	Cell 3   | Cell 4
+		#
+		$text = preg_replace_callback('
+			{
+				^							# Start of a line
+				[ ]{0,'.$less_than_tab.'}	# Allowed whitespace.
+				(\S.*[|].*) \n				# $1: Header row (at least one pipe)
+				
+				[ ]{0,'.$less_than_tab.'}	# Allowed whitespace.
+				([-:]+[ ]*[|][-| :]*) \n	# $2: Header underline
+				
+				(							# $3: Cells
+					(?>
+						.* [|] .* \n		# Row content
+					)*
+				)
+				(?=\n|\Z)					# Stop at final double newline.
+			}xm',
+			array(&$this, '_DoTable_callback'), $text);
+
+		return $text;
+	}
+	function _doTable_leadingPipe_callback($matches) {
+		$head		= $matches[1];
+		$underline	= $matches[2];
+		$content	= $matches[3];
+		
+		# Remove leading pipe for each row.
+		$content	= preg_replace('/^ *[|]/m', '', $content);
+		
+		return $this->_doTable_callback(array($matches[0], $head, $underline, $content));
+	}
+	function _doTable_callback($matches) {
+		$head		= $matches[1];
+		$underline	= $matches[2];
+		$content	= $matches[3];
+
+		# Remove any tailing pipes for each line.
+		$head		= preg_replace('/[|] *$/m', '', $head);
+		$underline	= preg_replace('/[|] *$/m', '', $underline);
+		$content	= preg_replace('/[|] *$/m', '', $content);
+		
+		# Reading alignement from header underline.
+		$separators	= preg_split('/ *[|] */', $underline);
+		foreach ($separators as $n => $s) {
+			if (preg_match('/^ *-+: *$/', $s))		$attr[$n] = ' align="right"';
+			else if (preg_match('/^ *:-+: *$/', $s))$attr[$n] = ' align="center"';
+			else if (preg_match('/^ *:-+ *$/', $s))	$attr[$n] = ' align="left"';
+			else									$attr[$n] = '';
+		}
+		
+		# Parsing span elements, including code spans, character escapes, 
+		# and inline HTML tags, so that pipes inside those gets ignored.
+		$head		= $this->parseSpan($head);
+		$headers	= preg_split('/ *[|] */', $head);
+		$col_count	= count($headers);
+		
+		# Write column headers.
+		$text = "<table>\n";
+		$text .= "<thead>\n";
+		$text .= "<tr>\n";
+		foreach ($headers as $n => $header)
+			$text .= "  <th$attr[$n]>".$this->runSpanGamut(trim($header))."</th>\n";
+		$text .= "</tr>\n";
+		$text .= "</thead>\n";
+		
+		# Split content by row.
+		$rows = explode("\n", trim($content, "\n"));
+		
+		$text .= "<tbody>\n";
+		foreach ($rows as $row) {
+			# Parsing span elements, including code spans, character escapes, 
+			# and inline HTML tags, so that pipes inside those gets ignored.
+			$row = $this->parseSpan($row);
+			
+			# Split row by cell.
+			$row_cells = preg_split('/ *[|] */', $row, $col_count);
+			$row_cells = array_pad($row_cells, $col_count, '');
+			
+			$text .= "<tr>\n";
+			foreach ($row_cells as $n => $cell)
+				$text .= "  <td$attr[$n]>".$this->runSpanGamut(trim($cell))."</td>\n";
+			$text .= "</tr>\n";
+		}
+		$text .= "</tbody>\n";
+		$text .= "</table>";
+		
+		return $this->hashBlock($text) . "\n";
+	}
+
+	
+	function doDefLists($text) {
+	#
+	# Form HTML definition lists.
+	#
+		$less_than_tab = $this->tab_width - 1;
+
+		# Re-usable pattern to match any entire dl list:
+		$whole_list_re = '(?>
+			(								# $1 = whole list
+			  (								# $2
+				[ ]{0,'.$less_than_tab.'}
+				((?>.*\S.*\n)+)				# $3 = defined term
+				\n?
+				[ ]{0,'.$less_than_tab.'}:[ ]+ # colon starting definition
+			  )
+			  (?s:.+?)
+			  (								# $4
+				  \z
+				|
+				  \n{2,}
+				  (?=\S)
+				  (?!						# Negative lookahead for another term
+					[ ]{0,'.$less_than_tab.'}
+					(?: \S.*\n )+?			# defined term
+					\n?
+					[ ]{0,'.$less_than_tab.'}:[ ]+ # colon starting definition
+				  )
+				  (?!						# Negative lookahead for another definition
+					[ ]{0,'.$less_than_tab.'}:[ ]+ # colon starting definition
+				  )
+			  )
+			)
+		)'; // mx
+
+		$text = preg_replace_callback('{
+				(?>\A\n?|(?<=\n\n))
+				'.$whole_list_re.'
+			}mx',
+			array(&$this, '_doDefLists_callback'), $text);
+
+		return $text;
+	}
+	function _doDefLists_callback($matches) {
+		# Re-usable patterns to match list item bullets and number markers:
+		$list = $matches[1];
+		
+		# Turn double returns into triple returns, so that we can make a
+		# paragraph for the last item in a list, if necessary:
+		$result = trim($this->processDefListItems($list));
+		$result = "<dl>\n" . $result . "\n</dl>";
+		return $this->hashBlock($result) . "\n\n";
+	}
+
+
+	function processDefListItems($list_str) {
+	#
+	#	Process the contents of a single definition list, splitting it
+	#	into individual term and definition list items.
+	#
+		$less_than_tab = $this->tab_width - 1;
+		
+		# trim trailing blank lines:
+		$list_str = preg_replace("/\n{2,}\\z/", "\n", $list_str);
+
+		# Process definition terms.
+		$list_str = preg_replace_callback('{
+			(?>\A\n?|\n\n+)					# leading line
+			(								# definition terms = $1
+				[ ]{0,'.$less_than_tab.'}	# leading whitespace
+				(?![:][ ]|[ ])				# negative lookahead for a definition 
+											#   mark (colon) or more whitespace.
+				(?> \S.* \n)+?				# actual term (not whitespace).	
+			)			
+			(?=\n?[ ]{0,3}:[ ])				# lookahead for following line feed 
+											#   with a definition mark.
+			}xm',
+			array(&$this, '_processDefListItems_callback_dt'), $list_str);
+
+		# Process actual definitions.
+		$list_str = preg_replace_callback('{
+			\n(\n+)?						# leading line = $1
+			(								# marker space = $2
+				[ ]{0,'.$less_than_tab.'}	# whitespace before colon
+				[:][ ]+						# definition mark (colon)
+			)
+			((?s:.+?))						# definition text = $3
+			(?= \n+ 						# stop at next definition mark,
+				(?:							# next term or end of text
+					[ ]{0,'.$less_than_tab.'} [:][ ]	|
+					<dt> | \z
+				)						
+			)					
+			}xm',
+			array(&$this, '_processDefListItems_callback_dd'), $list_str);
+
+		return $list_str;
+	}
+	function _processDefListItems_callback_dt($matches) {
+		$terms = explode("\n", trim($matches[1]));
+		$text = '';
+		foreach ($terms as $term) {
+			$term = $this->runSpanGamut(trim($term));
+			$text .= "\n<dt>" . $term . "</dt>";
+		}
+		return $text . "\n";
+	}
+	function _processDefListItems_callback_dd($matches) {
+		$leading_line	= $matches[1];
+		$marker_space	= $matches[2];
+		$def			= $matches[3];
+
+		if ($leading_line || preg_match('/\n{2,}/', $def)) {
+			# Replace marker with the appropriate whitespace indentation
+			$def = str_repeat(' ', strlen($marker_space)) . $def;
+			$def = $this->runBlockGamut($this->outdent($def . "\n\n"));
+			$def = "\n". $def ."\n";
+		}
+		else {
+			$def = rtrim($def);
+			$def = $this->runSpanGamut($this->outdent($def));
+		}
+
+		return "\n<dd>" . $def . "</dd>\n";
+	}
+
+
+	function doFencedCodeBlocks($text) {
+	#
+	# Adding the fenced code block syntax to regular Markdown:
+	#
+	# ~~~
+	# Code block
+	# ~~~
+	#
+		$less_than_tab = $this->tab_width;
+		
+		$text = preg_replace_callback('{
+				(?:\n|\A)
+				# 1: Opening marker
+				(
+					~{3,} # Marker: three tilde or more.
+				)
+				[ ]*
+				(?:
+					[.]?([-_:a-zA-Z0-9]+) # 2: standalone class name
+				|
+					'.$this->id_class_attr_catch_re.' # 3: Extra attributes
+				)?
+				[ ]* \n # Whitespace and newline following marker.
+				
+				# 4: Content
+				(
+					(?>
+						(?!\1 [ ]* \n)	# Not a closing marker.
+						.*\n+
+					)+
+				)
+				
+				# Closing marker.
+				\1 [ ]* \n
+			}xm',
+			array(&$this, '_doFencedCodeBlocks_callback'), $text);
+
+		return $text;
+	}
+	function _doFencedCodeBlocks_callback($matches) {
+		$classname =& $matches[2];
+		$attrs     =& $matches[3];
+		$codeblock = $matches[4];
+		$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
+		$codeblock = preg_replace_callback('/^\n+/',
+			array(&$this, '_doFencedCodeBlocks_newlines'), $codeblock);
+
+		if ($classname != "") {
+			if ($classname{0} == '.')
+				$classname = substr($classname, 1);
+			$attr_str = ' class="'.$this->code_class_prefix.$classname.'"';
+		} else {
+			$attr_str = $this->doExtraAttributes($this->code_attr_on_pre ? "pre" : "code", $attrs);
+		}
+		$pre_attr_str  = $this->code_attr_on_pre ? $attr_str : '';
+		$code_attr_str = $this->code_attr_on_pre ? '' : $attr_str;
+		$codeblock  = "<pre$pre_attr_str><code$code_attr_str>$codeblock</code></pre>";
+		
+		return "\n\n".$this->hashBlock($codeblock)."\n\n";
+	}
+	function _doFencedCodeBlocks_newlines($matches) {
+		return str_repeat("<br$this->empty_element_suffix", 
+			strlen($matches[0]));
+	}
+
+
+	#
+	# Redefining emphasis markers so that emphasis by underscore does not
+	# work in the middle of a word.
+	#
+	var $em_relist = array(
+		''  => '(?:(?<!\*)\*(?!\*)|(?<![a-zA-Z0-9_])_(?!_))(?=\S|$)(?![\.,:;]\s)',
+		'*' => '(?<=\S|^)(?<!\*)\*(?!\*)',
+		'_' => '(?<=\S|^)(?<!_)_(?![a-zA-Z0-9_])',
+		);
+	var $strong_relist = array(
+		''   => '(?:(?<!\*)\*\*(?!\*)|(?<![a-zA-Z0-9_])__(?!_))(?=\S|$)(?![\.,:;]\s)',
+		'**' => '(?<=\S|^)(?<!\*)\*\*(?!\*)',
+		'__' => '(?<=\S|^)(?<!_)__(?![a-zA-Z0-9_])',
+		);
+	var $em_strong_relist = array(
+		''    => '(?:(?<!\*)\*\*\*(?!\*)|(?<![a-zA-Z0-9_])___(?!_))(?=\S|$)(?![\.,:;]\s)',
+		'***' => '(?<=\S|^)(?<!\*)\*\*\*(?!\*)',
+		'___' => '(?<=\S|^)(?<!_)___(?![a-zA-Z0-9_])',
+		);
+
+
+	function formParagraphs($text) {
+	#
+	#	Params:
+	#		$text - string to process with html <p> tags
+	#
+		# Strip leading and trailing lines:
+		$text = preg_replace('/\A\n+|\n+\z/', '', $text);
+		
+		$grafs = preg_split('/\n{2,}/', $text, -1, PREG_SPLIT_NO_EMPTY);
+
+		#
+		# Wrap <p> tags and unhashify HTML blocks
+		#
+		foreach ($grafs as $key => $value) {
+			$value = trim($this->runSpanGamut($value));
+			
+			# Check if this should be enclosed in a paragraph.
+			# Clean tag hashes & block tag hashes are left alone.
+			$is_p = !preg_match('/^B\x1A[0-9]+B|^C\x1A[0-9]+C$/', $value);
+			
+			if ($is_p) {
+				$value = "<p>$value</p>";
+			}
+			$grafs[$key] = $value;
+		}
+		
+		# Join grafs in one text, then unhash HTML tags. 
+		$text = implode("\n\n", $grafs);
+		
+		# Finish by removing any tag hashes still present in $text.
+		$text = $this->unhash($text);
+		
+		return $text;
+	}
+	
+	
+	### Footnotes
+	
+	function stripFootnotes($text) {
+	#
+	# Strips link definitions from text, stores the URLs and titles in
+	# hash references.
+	#
+		$less_than_tab = $this->tab_width - 1;
+
+		# Link defs are in the form: [^id]: url "optional title"
+		$text = preg_replace_callback('{
+			^[ ]{0,'.$less_than_tab.'}\[\^(.+?)\][ ]?:	# note_id = $1
+			  [ ]*
+			  \n?					# maybe *one* newline
+			(						# text = $2 (no blank lines allowed)
+				(?:					
+					.+				# actual text
+				|
+					\n				# newlines but 
+					(?!\[\^.+?\]:\s)# negative lookahead for footnote marker.
+					(?!\n+[ ]{0,3}\S)# ensure line is not blank and followed 
+									# by non-indented content
+				)*
+			)		
+			}xm',
+			array(&$this, '_stripFootnotes_callback'),
+			$text);
+		return $text;
+	}
+	function _stripFootnotes_callback($matches) {
+		$note_id = $this->fn_id_prefix . $matches[1];
+		$this->footnotes[$note_id] = $this->outdent($matches[2]);
+		return ''; # String that will replace the block
+	}
+
+
+	function doFootnotes($text) {
+	#
+	# Replace footnote references in $text [^id] with a special text-token 
+	# which will be replaced by the actual footnote marker in appendFootnotes.
+	#
+		if (!$this->in_anchor) {
+			$text = preg_replace('{\[\^(.+?)\]}', "F\x1Afn:\\1\x1A:", $text);
+		}
+		return $text;
+	}
+
+	
+	function appendFootnotes($text) {
+	#
+	# Append footnote list to text.
+	#
+		$text = preg_replace_callback('{F\x1Afn:(.*?)\x1A:}', 
+			array(&$this, '_appendFootnotes_callback'), $text);
+	
+		if (!empty($this->footnotes_ordered)) {
+			$text .= "\n\n";
+			$text .= "<div class=\"footnotes\">\n";
+			$text .= "<hr". $this->empty_element_suffix ."\n";
+			$text .= "<ol>\n\n";
+			
+			$attr = " rev=\"footnote\"";
+			if ($this->fn_backlink_class != "") {
+				$class = $this->fn_backlink_class;
+				$class = $this->encodeAttribute($class);
+				$attr .= " class=\"$class\"";
+			}
+			if ($this->fn_backlink_title != "") {
+				$title = $this->fn_backlink_title;
+				$title = $this->encodeAttribute($title);
+				$attr .= " title=\"$title\"";
+			}
+			$num = 0;
+			
+			while (!empty($this->footnotes_ordered)) {
+				$footnote = reset($this->footnotes_ordered);
+				$note_id = key($this->footnotes_ordered);
+				unset($this->footnotes_ordered[$note_id]);
+				$ref_count = $this->footnotes_ref_count[$note_id];
+				unset($this->footnotes_ref_count[$note_id]);
+				unset($this->footnotes[$note_id]);
+				
+				$footnote .= "\n"; # Need to append newline before parsing.
+				$footnote = $this->runBlockGamut("$footnote\n");				
+				$footnote = preg_replace_callback('{F\x1Afn:(.*?)\x1A:}', 
+					array(&$this, '_appendFootnotes_callback'), $footnote);
+				
+				$attr = str_replace("%%", ++$num, $attr);
+				$note_id = $this->encodeAttribute($note_id);
+
+				# Prepare backlink, multiple backlinks if multiple references
+				$backlink = "<a href=\"#fnref:$note_id\"$attr>&#8617;</a>";
+				for ($ref_num = 2; $ref_num <= $ref_count; ++$ref_num) {
+					$backlink .= " <a href=\"#fnref$ref_num:$note_id\"$attr>&#8617;</a>";
+				}
+				# Add backlink to last paragraph; create new paragraph if needed.
+				if (preg_match('{</p>$}', $footnote)) {
+					$footnote = substr($footnote, 0, -4) . "&#160;$backlink</p>";
+				} else {
+					$footnote .= "\n\n<p>$backlink</p>";
+				}
+				
+				$text .= "<li id=\"fn:$note_id\">\n";
+				$text .= $footnote . "\n";
+				$text .= "</li>\n\n";
+			}
+			
+			$text .= "</ol>\n";
+			$text .= "</div>";
+		}
+		return $text;
+	}
+	function _appendFootnotes_callback($matches) {
+		$node_id = $this->fn_id_prefix . $matches[1];
+		
+		# Create footnote marker only if it has a corresponding footnote *and*
+		# the footnote hasn't been used by another marker.
+		if (isset($this->footnotes[$node_id])) {
+			$num =& $this->footnotes_numbers[$node_id];
+			if (!isset($num)) {
+				# Transfer footnote content to the ordered list and give it its
+				# number
+				$this->footnotes_ordered[$node_id] = $this->footnotes[$node_id];
+				$this->footnotes_ref_count[$node_id] = 1;
+				$num = $this->footnote_counter++;
+				$ref_count_mark = '';
+			} else {
+				$ref_count_mark = $this->footnotes_ref_count[$node_id] += 1;
+			}
+			
+			$attr = " rel=\"footnote\"";
+			if ($this->fn_link_class != "") {
+				$class = $this->fn_link_class;
+				$class = $this->encodeAttribute($class);
+				$attr .= " class=\"$class\"";
+			}
+			if ($this->fn_link_title != "") {
+				$title = $this->fn_link_title;
+				$title = $this->encodeAttribute($title);
+				$attr .= " title=\"$title\"";
+			}
+			
+			$attr = str_replace("%%", $num, $attr);
+			$node_id = $this->encodeAttribute($node_id);
+			
+			return
+				"<sup id=\"fnref$ref_count_mark:$node_id\">".
+				"<a href=\"#fn:$node_id\"$attr>$num</a>".
+				"</sup>";
+		}
+		
+		return "[^".$matches[1]."]";
+	}
+		
+	
+	### Abbreviations ###
+	
+	function stripAbbreviations($text) {
+	#
+	# Strips abbreviations from text, stores titles in hash references.
+	#
+		$less_than_tab = $this->tab_width - 1;
+
+		# Link defs are in the form: [id]*: url "optional title"
+		$text = preg_replace_callback('{
+			^[ ]{0,'.$less_than_tab.'}\*\[(.+?)\][ ]?:	# abbr_id = $1
+			(.*)					# text = $2 (no blank lines allowed)	
+			}xm',
+			array(&$this, '_stripAbbreviations_callback'),
+			$text);
+		return $text;
+	}
+	function _stripAbbreviations_callback($matches) {
+		$abbr_word = $matches[1];
+		$abbr_desc = $matches[2];
+		if ($this->abbr_word_re)
+			$this->abbr_word_re .= '|';
+		$this->abbr_word_re .= preg_quote($abbr_word);
+		$this->abbr_desciptions[$abbr_word] = trim($abbr_desc);
+		return ''; # String that will replace the block
+	}
+	
+	
+	function doAbbreviations($text) {
+	#
+	# Find defined abbreviations in text and wrap them in <abbr> elements.
+	#
+		if ($this->abbr_word_re) {
+			// cannot use the /x modifier because abbr_word_re may 
+			// contain significant spaces:
+			$text = preg_replace_callback('{'.
+				'(?<![\w\x1A])'.
+				'(?:'.$this->abbr_word_re.')'.
+				'(?![\w\x1A])'.
+				'}', 
+				array(&$this, '_doAbbreviations_callback'), $text);
+		}
+		return $text;
+	}
+	function _doAbbreviations_callback($matches) {
+		$abbr = $matches[0];
+		if (isset($this->abbr_desciptions[$abbr])) {
+			$desc = $this->abbr_desciptions[$abbr];
+			if (empty($desc)) {
+				return $this->hashPart("<abbr>$abbr</abbr>");
+			} else {
+				$desc = $this->encodeAttribute($desc);
+				return $this->hashPart("<abbr title=\"$desc\">$abbr</abbr>");
+			}
+		} else {
+			return $matches[0];
+		}
+	}
+
+}
+
+
 /*
 
-PHP Markdown
-============
+PHP Markdown Extra
+==================
 
 Description
 -----------
 
-This is a PHP translation of the original Markdown formatter written in
-Perl by John Gruber.
+This is a PHP port of the original Markdown formatter written in Perl 
+by John Gruber. This special "Extra" version of PHP Markdown features 
+further enhancements to the syntax for making additional constructs 
+such as tables and definition list.
 
 Markdown is a text-to-HTML filter; it translates an easy-to-read /
 easy-to-write structured text format into HTML. Markdown's text format
@@ -1596,8 +2887,8 @@ See the readme file for detailed release notes for this version.
 Copyright and License
 ---------------------
 
-PHP Markdown  
-Copyright (c) 2004-2013 Michel Fortin  
+PHP Markdown & Extra
+Copyright (c) 2004-2013 Michel Fortin
 <http://michelf.ca/>  
 All rights reserved.
 

--- a/smartypants.php
+++ b/smartypants.php
@@ -1,46 +1,93 @@
 <?php
-
 #
 # SmartyPants  -  Smart punctuation for web sites
 #
-# by John Gruber
+# PHP SmartyPants  
+# Copyright (c) 2004-2013 Michel Fortin
+# <http://michelf.ca/>
+#
+# Original SmartyPants
+# Copyright (c) 2003-2004 John Gruber
 # <http://daringfireball.net>
 #
-# PHP port by Michel Fortin
-# <http://www.michelf.com/>
+
+
+define( 'SMARTYPANTS_VERSION',  "1.5.1f" ); # Unreleased
+
+
 #
-# Copyright (c) 2003-2004 John Gruber
-# Copyright (c) 2004-2005 Michel Fortin
+# Default configuration:
 #
+#  1  ->  "--" for em-dashes; no en-dash support  
+#  2  ->  "---" for em-dashes; "--" for en-dashes  
+#  3  ->  "--" for em-dashes; "---" for en-dashes  
+#  See docs for more configuration options.
+#
+define( 'SMARTYPANTS_ATTR',    1 );
 
 
-global	$SmartyPantsPHPVersion, $SmartyPantsSyntaxVersion,
-		$smartypants_attr, $sp_tags_to_skip;
-
-$SmartyPantsPHPVersion    = '1.5.1e'; # Fru 9 Dec 2005
-$SmartyPantsSyntaxVersion = '1.5.1';  # Fri 12 Mar 2004
+# SmartyPants will not alter the content of these tags:
+define( 'SMARTYPANTS_TAGS_TO_SKIP', 'pre|code|kbd|script|style|math');
 
 
-# Configurable variables:
-$smartypants_attr = "1";  # Change this to configure.
-						  #  1 =>  "--" for em-dashes; no en-dash support
-						  #  2 =>  "---" for em-dashes; "--" for en-dashes
-						  #  3 =>  "--" for em-dashes; "---" for en-dashes
-						  #  See docs for more configuration options.
+### Standard Function Interface ###
 
-# Globals:
-$sp_tags_to_skip = '<(/?)(?:pre|code|kbd|script|math)[\s>]';
+define( 'SMARTYPANTS_PARSER_CLASS', 'SmartyPants_Parser' );
+
+function SmartyPants($text, $attr = SMARTYPANTS_ATTR) {
+#
+# Initialize the parser and return the result of its transform method.
+#
+	# Setup static parser array.
+	static $parser = array();
+	if (!isset($parser[$attr])) {
+		$parser_class = SMARTYPANTS_PARSER_CLASS;
+		$parser[$attr] = new $parser_class($attr);
+	}
+
+	# Transform text using parser.
+	return $parser[$attr]->transform($text);
+}
+
+function SmartQuotes($text, $attr = null) {
+	switch ($attr) {
+		case 0:  return $text;
+		case 2:  $attr = 'qb'; break;
+		default: $attr = 'q'; break;
+	}
+	return SmartyPants($text, $attr);
+}
+
+function SmartDashes($text, $attr = null) {
+	switch ($attr) {
+		case 0:  return $text;
+		case 2:  $attr = 'D'; break;
+		case 3:  $attr = 'i'; break;
+		default: $attr = 'd'; break;
+	}
+	return SmartyPants($text, $attr);
+}
+
+function SmartElipsis($text, $attr = null) {
+	switch ($attr) {
+		case 0:  return $text;
+		default: $attr = 'e'; break;
+	}
+	return SmartyPants($text, $attr);
+}
 
 
-# -- WordPress plugin interface -----------------------------------------------
+### WordPress Plugin Interface ###
+
 /*
 Plugin Name: SmartyPants
-Plugin URI: http://www.michelf.com/projects/php-smartypants/
+Plugin URI: http://michelf.ca/projects/php-smartypants/
 Description: SmartyPants is a web publishing utility that translates plain ASCII punctuation characters into &#8220;smart&#8221; typographic punctuation HTML entities. This plugin <strong>replace the default WordPress Texturize algorithm</strong> for the content and the title of your posts, the comments body and author name, and everywhere else Texturize normally apply. Based on the original Perl version by <a href="http://daringfireball.net/">John Gruber</a>.
-Version: 1.5.1e
+Version: 1.5.1f
 Author: Michel Fortin
-Author URI: http://www.michelf.com/
+Author URI: http://michelf.ca/
 */
+
 if (isset($wp_version)) {
 	# Remove default Texturize filter that would conflict with SmartyPants.
 	remove_filter('category_description', 'wptexturize');
@@ -51,37 +98,47 @@ if (isset($wp_version)) {
 	remove_filter('the_title', 'wptexturize');
 	remove_filter('the_content', 'wptexturize');
 	remove_filter('the_excerpt', 'wptexturize');
-	# Add SmartyPants filter with priority 10 (same as Texturize).
-	add_filter('category_description', 'SmartyPants', 10);
-	add_filter('list_cats', 'SmartyPants', 10);
-	add_filter('comment_author', 'SmartyPants', 10);
-	add_filter('comment_text', 'SmartyPants', 10);
-	add_filter('single_post_title', 'SmartyPants', 10);
-	add_filter('the_title', 'SmartyPants', 10);
-	add_filter('the_content', 'SmartyPants', 10);
-	add_filter('the_excerpt', 'SmartyPants', 10);
+	remove_filter('the_tags', 'wptexturize');
+	# Add SmartyPants filter.
+	add_filter('category_description', 'SmartyPants', 11);
+	add_filter('list_cats', 'SmartyPants', 11);
+	add_filter('comment_author', 'SmartyPants', 11);
+	add_filter('comment_text', 'SmartyPants', 11);
+	add_filter('single_post_title', 'SmartyPants', 11);
+	add_filter('the_title', 'SmartyPants', 11);
+	add_filter('the_content', 'SmartyPants', 11);
+	add_filter('the_excerpt', 'SmartyPants', 11);
+	add_filter('the_tags', 'SmartyPants', 11);
 }
 
-# -- Smarty Modifier Interface ------------------------------------------------
+
+### Smarty Modifier Interface ###
+
 function smarty_modifier_smartypants($text, $attr = NULL) {
 	return SmartyPants($text, $attr);
 }
 
 
+#
+# SmartyPants Parser
+#
 
-function SmartyPants($text, $attr = NULL, $ctx = NULL) {
-	global $smartypants_attr, $sp_tags_to_skip;
-	# Paramaters:
-	$text;   # text to be parsed
-	$attr;   # value of the smart_quotes="" attribute
-	$ctx;    # MT context object (unused)
-	if ($attr == NULL) $attr = $smartypants_attr;
+class SmartyPants_Parser {
 
 	# Options to specify which transformations to make:
-	$do_stupefy = FALSE;
-	$convert_quot = 0;  # should we translate &quot; entities into normal quotes?
+	var $do_nothing   = 0;
+	var $do_quotes    = 0;
+	var $do_backticks = 0;
+	var $do_dashes    = 0;
+	var $do_ellipses  = 0;
+	var $do_stupefy   = 0;
+	var $convert_quot = 0; # should we translate &quot; entities into normal quotes?
 
-	# Parse attributes:
+	function SmartyPants_Parser($attr = SMARTYPANTS_ATTR) {
+	#
+	# Initialize a SmartyPants_Parser with certain attributes.
+	#
+	# Parser attributes:
 	# 0 : do nothing
 	# 1 : set all
 	# 2 : set all, using old school en- and em- dash shortcuts
@@ -95,587 +152,418 @@ function SmartyPants($text, $attr = NULL, $ctx = NULL) {
 	# i : inverted old school dashes
 	# e : ellipses
 	# w : convert &quot; entities to " for Dreamweaver users
-
-	if ($attr == "0") {
-		# Do nothing.
-		return $text;
-	}
-	else if ($attr == "1") {
-		# Do everything, turn all options on.
-		$do_quotes    = 1;
-		$do_backticks = 1;
-		$do_dashes    = 1;
-		$do_ellipses  = 1;
-	}
-	else if ($attr == "2") {
-		# Do everything, turn all options on, use old school dash shorthand.
-		$do_quotes    = 1;
-		$do_backticks = 1;
-		$do_dashes    = 2;
-		$do_ellipses  = 1;
-	}
-	else if ($attr == "3") {
-		# Do everything, turn all options on, use inverted old school dash shorthand.
-		$do_quotes    = 1;
-		$do_backticks = 1;
-		$do_dashes    = 3;
-		$do_ellipses  = 1;
-	}
-	else if ($attr == "-1") {
-		# Special "stupefy" mode.
-		$do_stupefy   = 1;
-	}
-	else {
-		$chars = preg_split('//', $attr);
-		foreach ($chars as $c){
-			if      ($c == "q") { $do_quotes    = 1; }
-			else if ($c == "b") { $do_backticks = 1; }
-			else if ($c == "B") { $do_backticks = 2; }
-			else if ($c == "d") { $do_dashes    = 1; }
-			else if ($c == "D") { $do_dashes    = 2; }
-			else if ($c == "i") { $do_dashes    = 3; }
-			else if ($c == "e") { $do_ellipses  = 1; }
-			else if ($c == "w") { $convert_quot = 1; }
-			else {
-				# Unknown attribute option, ignore.
+	#
+		if ($attr == "0") {
+			$this->do_nothing   = 1;
+		}
+		else if ($attr == "1") {
+			# Do everything, turn all options on.
+			$this->do_quotes    = 1;
+			$this->do_backticks = 1;
+			$this->do_dashes    = 1;
+			$this->do_ellipses  = 1;
+		}
+		else if ($attr == "2") {
+			# Do everything, turn all options on, use old school dash shorthand.
+			$this->do_quotes    = 1;
+			$this->do_backticks = 1;
+			$this->do_dashes    = 2;
+			$this->do_ellipses  = 1;
+		}
+		else if ($attr == "3") {
+			# Do everything, turn all options on, use inverted old school dash shorthand.
+			$this->do_quotes    = 1;
+			$this->do_backticks = 1;
+			$this->do_dashes    = 3;
+			$this->do_ellipses  = 1;
+		}
+		else if ($attr == "-1") {
+			# Special "stupefy" mode.
+			$this->do_stupefy   = 1;
+		}
+		else {
+			$chars = preg_split('//', $attr);
+			foreach ($chars as $c){
+				if      ($c == "q") { $this->do_quotes    = 1; }
+				else if ($c == "b") { $this->do_backticks = 1; }
+				else if ($c == "B") { $this->do_backticks = 2; }
+				else if ($c == "d") { $this->do_dashes    = 1; }
+				else if ($c == "D") { $this->do_dashes    = 2; }
+				else if ($c == "i") { $this->do_dashes    = 3; }
+				else if ($c == "e") { $this->do_ellipses  = 1; }
+				else if ($c == "w") { $this->convert_quot = 1; }
+				else {
+					# Unknown attribute option, ignore.
+				}
 			}
 		}
 	}
 
-	$tokens = _TokenizeHTML($text);
-	$result = '';
-	$in_pre = 0;  # Keep track of when we're inside <pre> or <code> tags.
+	function transform($text) {
 
-	$prev_token_last_char = "";     # This is a cheat, used to get some context
+		if ($this->do_nothing) {
+			return $text;
+		}
+
+		$tokens = $this->tokenizeHTML($text);
+		$result = '';
+		$in_pre = 0;  # Keep track of when we're inside <pre> or <code> tags.
+
+		$prev_token_last_char = ""; # This is a cheat, used to get some context
 									# for one-character tokens that consist of 
 									# just a quote char. What we do is remember
 									# the last character of the previous text
 									# token, to use as context to curl single-
 									# character quote tokens correctly.
 
-	foreach ($tokens as $cur_token) {
-		if ($cur_token[0] == "tag") {
-			# Don't mess with quotes inside tags.
-			$result .= $cur_token[1];
-			if (preg_match("@$sp_tags_to_skip@", $cur_token[1], $matches)) {
-				$in_pre = isset($matches[1]) && $matches[1] == '/' ? 0 : 1;
+		foreach ($tokens as $cur_token) {
+			if ($cur_token[0] == "tag") {
+				# Don't mess with quotes inside tags.
+				$result .= $cur_token[1];
+				if (preg_match('@<(/?)(?:'.SMARTYPANTS_TAGS_TO_SKIP.')[\s>]@', $cur_token[1], $matches)) {
+					$in_pre = isset($matches[1]) && $matches[1] == '/' ? 0 : 1;
+				}
+			} else {
+				$t = $cur_token[1];
+				$last_char = substr($t, -1); # Remember last char of this token before processing.
+				if (! $in_pre) {
+					$t = $this->educate($t, $prev_token_last_char);
+				}
+				$prev_token_last_char = $last_char;
+				$result .= $t;
 			}
-		} else {
-			$t = $cur_token[1];
-			$last_char = substr($t, -1); # Remember last char of this token before processing.
-			if (! $in_pre) {
-				$t = ProcessEscapes($t);
-
-				if ($convert_quot) {
-					$t = preg_replace('/&quot;/', '"', $t);
-				}
-
-				if ($do_dashes) {
-					if ($do_dashes == 1) $t = EducateDashes($t);
-					if ($do_dashes == 2) $t = EducateDashesOldSchool($t);
-					if ($do_dashes == 3) $t = EducateDashesOldSchoolInverted($t);
-				}
-
-				if ($do_ellipses) $t = EducateEllipses($t);
-
-				# Note: backticks need to be processed before quotes.
-				if ($do_backticks) {
-					$t = EducateBackticks($t);
-					if ($do_backticks == 2) $t = EducateSingleBackticks($t);
-				}
-
-				if ($do_quotes) {
-					if ($t == "'") {
-						# Special case: single-character ' token
-						if (preg_match('/\S/', $prev_token_last_char)) {
-							$t = "&#8217;";
-						}
-						else {
-							$t = "&#8216;";
-						}
-					}
-					else if ($t == '"') {
-						# Special case: single-character " token
-						if (preg_match('/\S/', $prev_token_last_char)) {
-							$t = "&#8221;";
-						}
-						else {
-							$t = "&#8220;";
-						}
-					}
-					else {
-						# Normal case:
-						$t = EducateQuotes($t);
-					}
-				}
-
-				if ($do_stupefy) $t = StupefyEntities($t);
-			}
-			$prev_token_last_char = $last_char;
-			$result .= $t;
 		}
+
+		return $result;
 	}
 
-	return $result;
-}
 
+	function educate($t, $prev_token_last_char) {
+		$t = $this->processEscapes($t);
 
-function SmartQuotes($text, $attr = NULL, $ctx = NULL) {
-	global $smartypants_attr, $sp_tags_to_skip;
-	# Paramaters:
-	$text;   # text to be parsed
-	$attr;   # value of the smart_quotes="" attribute
-	$ctx;    # MT context object (unused)
-	if ($attr == NULL) $attr = $smartypants_attr;
+		if ($this->convert_quot) {
+			$t = preg_replace('/&quot;/', '"', $t);
+		}
 
-	$do_backticks;   # should we educate ``backticks'' -style quotes?
+		if ($this->do_dashes) {
+			if ($this->do_dashes == 1) $t = $this->educateDashes($t);
+			if ($this->do_dashes == 2) $t = $this->educateDashesOldSchool($t);
+			if ($this->do_dashes == 3) $t = $this->educateDashesOldSchoolInverted($t);
+		}
 
-	if ($attr == 0) {
-		# do nothing;
-		return $text;
-	}
-	else if ($attr == 2) {
-		# smarten ``backticks'' -style quotes
-		$do_backticks = 1;
-	}
-	else {
-		$do_backticks = 0;
-	}
+		if ($this->do_ellipses) $t = $this->educateEllipses($t);
 
-	# Special case to handle quotes at the very end of $text when preceded by
-	# an HTML tag. Add a space to give the quote education algorithm a bit of
-	# context, so that it can guess correctly that it's a closing quote:
-	$add_extra_space = 0;
-	if (preg_match("/>['\"]\\z/", $text)) {
-		$add_extra_space = 1; # Remember, so we can trim the extra space later.
-		$text .= " ";
-	}
+		# Note: backticks need to be processed before quotes.
+		if ($this->do_backticks) {
+			$t = $this->educateBackticks($t);
+			if ($this->do_backticks == 2) $t = $this->educateSingleBackticks($t);
+		}
 
-	$tokens = _TokenizeHTML($text);
-	$result = '';
-	$in_pre = 0;  # Keep track of when we're inside <pre> or <code> tags
-
-	$prev_token_last_char = "";     # This is a cheat, used to get some context
-									# for one-character tokens that consist of 
-									# just a quote char. What we do is remember
-									# the last character of the previous text
-									# token, to use as context to curl single-
-									# character quote tokens correctly.
-
-	foreach ($tokens as $cur_token) {
-		if ($cur_token[0] == "tag") {
-			# Don't mess with quotes inside tags
-			$result .= $cur_token[1];
-			if (preg_match("@$sp_tags_to_skip@", $cur_token[1], $matches)) {
-				$in_pre = isset($matches[1]) && $matches[1] == '/' ? 0 : 1;
-			}
-		} else {
-			$t = $cur_token[1];
-			$last_char = substr($t, -1); # Remember last char of this token before processing.
-			if (! $in_pre) {
-				$t = ProcessEscapes($t);
-				if ($do_backticks) {
-					$t = EducateBackticks($t);
-				}
-
-				if ($t == "'") {
-					# Special case: single-character ' token
-					if (preg_match('/\S/', $prev_token_last_char)) {
-						$t = "&#8217;";
-					}
-					else {
-						$t = "&#8216;";
-					}
-				}
-				else if ($t == '"') {
-					# Special case: single-character " token
-					if (preg_match('/\S/', $prev_token_last_char)) {
-						$t = "&#8221;";
-					}
-					else {
-						$t = "&#8220;";
-					}
+		if ($this->do_quotes) {
+			if ($t == "'") {
+				# Special case: single-character ' token
+				if (preg_match('/\S/', $prev_token_last_char)) {
+					$t = "&#8217;";
 				}
 				else {
-					# Normal case:
-					$t = EducateQuotes($t);
+					$t = "&#8216;";
 				}
-
 			}
-			$prev_token_last_char = $last_char;
-			$result .= $t;
+			else if ($t == '"') {
+				# Special case: single-character " token
+				if (preg_match('/\S/', $prev_token_last_char)) {
+					$t = "&#8221;";
+				}
+				else {
+					$t = "&#8220;";
+				}
+			}
+			else {
+				# Normal case:
+				$t = $this->educateQuotes($t);
+			}
 		}
+
+		if ($this->do_stupefy) $t = $this->stupefyEntities($t);
+		
+		return $t;
 	}
 
-	if ($add_extra_space) {
-		preg_replace('/ \z/', '', $result);  # Trim trailing space if we added one earlier.
+
+	function educateQuotes($_) {
+	#
+	#   Parameter:  String.
+	#
+	#   Returns:    The string, with "educated" curly quote HTML entities.
+	#
+	#   Example input:  "Isn't this fun?"
+	#   Example output: &#8220;Isn&#8217;t this fun?&#8221;
+	#
+		# Make our own "punctuation" character class, because the POSIX-style
+		# [:PUNCT:] is only available in Perl 5.6 or later:
+		$punct_class = "[!\"#\\$\\%'()*+,-.\\/:;<=>?\\@\\[\\\\\]\\^_`{|}~]";
+
+		# Special case if the very first character is a quote
+		# followed by punctuation at a non-word-break. Close the quotes by brute force:
+		$_ = preg_replace(
+			array("/^'(?=$punct_class\\B)/", "/^\"(?=$punct_class\\B)/"),
+			array('&#8217;',                 '&#8221;'), $_);
+
+
+		# Special case for double sets of quotes, e.g.:
+		#   <p>He said, "'Quoted' words in a larger quote."</p>
+		$_ = preg_replace(
+			array("/\"'(?=\w)/",    "/'\"(?=\w)/"),
+			array('&#8220;&#8216;', '&#8216;&#8220;'), $_);
+
+		# Special case for decade abbreviations (the '80s):
+		$_ = preg_replace("/'(?=\\d{2}s)/", '&#8217;', $_);
+
+		$close_class = '[^\ \t\r\n\[\{\(\-]';
+		$dec_dashes = '&\#8211;|&\#8212;';
+
+		# Get most opening single quotes:
+		$_ = preg_replace("{
+			(
+				\\s          |   # a whitespace char, or
+				&nbsp;      |   # a non-breaking space entity, or
+				--          |   # dashes, or
+				&[mn]dash;  |   # named dash entities
+				$dec_dashes |   # or decimal entities
+				&\\#x201[34];    # or hex
+			)
+			'                   # the quote
+			(?=\\w)              # followed by a word character
+			}x", '\1&#8216;', $_);
+		# Single closing quotes:
+		$_ = preg_replace("{
+			($close_class)?
+			'
+			(?(1)|          # If $1 captured, then do nothing;
+			  (?=\\s | s\\b)  # otherwise, positive lookahead for a whitespace
+			)               # char or an 's' at a word ending position. This
+							# is a special case to handle something like:
+							# \"<i>Custer</i>'s Last Stand.\"
+			}xi", '\1&#8217;', $_);
+
+		# Any remaining single quotes should be opening ones:
+		$_ = str_replace("'", '&#8216;', $_);
+
+
+		# Get most opening double quotes:
+		$_ = preg_replace("{
+			(
+				\\s          |   # a whitespace char, or
+				&nbsp;      |   # a non-breaking space entity, or
+				--          |   # dashes, or
+				&[mn]dash;  |   # named dash entities
+				$dec_dashes |   # or decimal entities
+				&\\#x201[34];    # or hex
+			)
+			\"                   # the quote
+			(?=\\w)              # followed by a word character
+			}x", '\1&#8220;', $_);
+
+		# Double closing quotes:
+		$_ = preg_replace("{
+			($close_class)?
+			\"
+			(?(1)|(?=\\s))   # If $1 captured, then do nothing;
+							   # if not, then make sure the next char is whitespace.
+			}x", '\1&#8221;', $_);
+
+		# Any remaining quotes should be opening ones.
+		$_ = str_replace('"', '&#8220;', $_);
+
+		return $_;
 	}
-	return $result;
-}
 
 
-function SmartDashes($text, $attr = NULL, $ctx = NULL) {
-	global $smartypants_attr, $sp_tags_to_skip;
-	# Paramaters:
-	$text;   # text to be parsed
-	$attr;   # value of the smart_dashes="" attribute
-	$ctx;    # MT context object (unused)
-	if ($attr == NULL) $attr = $smartypants_attr;
+	function educateBackticks($_) {
+	#
+	#   Parameter:  String.
+	#   Returns:    The string, with ``backticks'' -style double quotes
+	#               translated into HTML curly quote entities.
+	#
+	#   Example input:  ``Isn't this fun?''
+	#   Example output: &#8220;Isn't this fun?&#8221;
+	#
 
-	# reference to the subroutine to use for dash education, default to EducateDashes:
-	$dash_sub_ref = 'EducateDashes';
-
-	if ($attr == 0) {
-		# do nothing;
-		return $text;
-	}
-	else if ($attr == 2) {
-		# use old smart dash shortcuts, "--" for en, "---" for em
-		$dash_sub_ref = 'EducateDashesOldSchool'; 
-	}
-	else if ($attr == 3) {
-		# inverse of 2, "--" for em, "---" for en
-		$dash_sub_ref = 'EducateDashesOldSchoolInverted'; 
+		$_ = str_replace(array("``",       "''",),
+						 array('&#8220;', '&#8221;'), $_);
+		return $_;
 	}
 
-	$tokens;
-	$tokens = _TokenizeHTML($text);
 
-	$result = '';
-	$in_pre = 0;  # Keep track of when we're inside <pre> or <code> tags
-	foreach ($tokens as $cur_token) {
-		if ($cur_token[0] == "tag") {
-			# Don't mess with quotes inside tags
-			$result .= $cur_token[1];
-			if (preg_match("@$sp_tags_to_skip@", $cur_token[1], $matches)) {
-				$in_pre = isset($matches[1]) && $matches[1] == '/' ? 0 : 1;
-			}
-		} else {
-			$t = $cur_token[1];
-			if (! $in_pre) {
-				$t = ProcessEscapes($t);
-				$t = $dash_sub_ref($t);
-			}
-			$result .= $t;
+	function educateSingleBackticks($_) {
+	#
+	#   Parameter:  String.
+	#   Returns:    The string, with `backticks' -style single quotes
+	#               translated into HTML curly quote entities.
+	#
+	#   Example input:  `Isn't this fun?'
+	#   Example output: &#8216;Isn&#8217;t this fun?&#8217;
+	#
+
+		$_ = str_replace(array("`",       "'",),
+						 array('&#8216;', '&#8217;'), $_);
+		return $_;
+	}
+
+
+	function educateDashes($_) {
+	#
+	#   Parameter:  String.
+	#
+	#   Returns:    The string, with each instance of "--" translated to
+	#               an em-dash HTML entity.
+	#
+
+		$_ = str_replace('--', '&#8212;', $_);
+		return $_;
+	}
+
+
+	function educateDashesOldSchool($_) {
+	#
+	#   Parameter:  String.
+	#
+	#   Returns:    The string, with each instance of "--" translated to
+	#               an en-dash HTML entity, and each "---" translated to
+	#               an em-dash HTML entity.
+	#
+
+		#                      em         en
+		$_ = str_replace(array("---",     "--",),
+						 array('&#8212;', '&#8211;'), $_);
+		return $_;
+	}
+
+
+	function educateDashesOldSchoolInverted($_) {
+	#
+	#   Parameter:  String.
+	#
+	#   Returns:    The string, with each instance of "--" translated to
+	#               an em-dash HTML entity, and each "---" translated to
+	#               an en-dash HTML entity. Two reasons why: First, unlike the
+	#               en- and em-dash syntax supported by
+	#               EducateDashesOldSchool(), it's compatible with existing
+	#               entries written before SmartyPants 1.1, back when "--" was
+	#               only used for em-dashes.  Second, em-dashes are more
+	#               common than en-dashes, and so it sort of makes sense that
+	#               the shortcut should be shorter to type. (Thanks to Aaron
+	#               Swartz for the idea.)
+	#
+
+		#                      en         em
+		$_ = str_replace(array("---",     "--",),
+						 array('&#8211;', '&#8212;'), $_);
+		return $_;
+	}
+
+
+	function educateEllipses($_) {
+	#
+	#   Parameter:  String.
+	#   Returns:    The string, with each instance of "..." translated to
+	#               an ellipsis HTML entity. Also converts the case where
+	#               there are spaces between the dots.
+	#
+	#   Example input:  Huh...?
+	#   Example output: Huh&#8230;?
+	#
+
+		$_ = str_replace(array("...",     ". . .",), '&#8230;', $_);
+		return $_;
+	}
+
+
+	function stupefyEntities($_) {
+	#
+	#   Parameter:  String.
+	#   Returns:    The string, with each SmartyPants HTML entity translated to
+	#               its ASCII counterpart.
+	#
+	#   Example input:  &#8220;Hello &#8212; world.&#8221;
+	#   Example output: "Hello -- world."
+	#
+
+							#  en-dash    em-dash
+		$_ = str_replace(array('&#8211;', '&#8212;'),
+						 array('-',       '--'), $_);
+
+		# single quote         open       close
+		$_ = str_replace(array('&#8216;', '&#8217;'), "'", $_);
+
+		# double quote         open       close
+		$_ = str_replace(array('&#8220;', '&#8221;'), '"', $_);
+
+		$_ = str_replace('&#8230;', '...', $_); # ellipsis
+
+		return $_;
+	}
+
+
+	function processEscapes($_) {
+	#
+	#   Parameter:  String.
+	#   Returns:    The string, with after processing the following backslash
+	#               escape sequences. This is useful if you want to force a "dumb"
+	#               quote or other character to appear.
+	#
+	#               Escape  Value
+	#               ------  -----
+	#               \\      &#92;
+	#               \"      &#34;
+	#               \'      &#39;
+	#               \.      &#46;
+	#               \-      &#45;
+	#               \`      &#96;
+	#
+		$_ = str_replace(
+			array('\\\\',  '\"',    "\'",    '\.',    '\-',    '\`'),
+			array('&#92;', '&#34;', '&#39;', '&#46;', '&#45;', '&#96;'), $_);
+
+		return $_;
+	}
+
+
+	function tokenizeHTML($str) {
+	#
+	#   Parameter:  String containing HTML markup.
+	#   Returns:    An array of the tokens comprising the input
+	#               string. Each token is either a tag (possibly with nested,
+	#               tags contained therein, such as <a href="<MTFoo>">, or a
+	#               run of text between tags. Each element of the array is a
+	#               two-element array; the first is either 'tag' or 'text';
+	#               the second is the actual value.
+	#
+	#
+	#   Regular expression derived from the _tokenize() subroutine in 
+	#   Brad Choate's MTRegex plugin.
+	#   <http://www.bradchoate.com/past/mtregex.php>
+	#
+		$index = 0;
+		$tokens = array();
+
+		$match = '(?s:<!--.*?-->)|'.	# comment
+				 '(?s:<\?.*?\?>)|'.				# processing instruction
+												# regular tags
+				 '(?:<[/!$]?[-a-zA-Z0-9:]+\b(?>[^"\'>]+|"[^"]*"|\'[^\']*\')*>)'; 
+
+		$parts = preg_split("{($match)}", $str, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+		foreach ($parts as $part) {
+			if (++$index % 2 && $part != '') 
+				$tokens[] = array('text', $part);
+			else
+				$tokens[] = array('tag', $part);
 		}
-	}
-	return $result;
-}
-
-
-function SmartEllipses($text, $attr = NULL, $ctx = NULL) {
-	# Paramaters:
-	$text;   # text to be parsed
-	$attr;   # value of the smart_ellipses="" attribute
-	$ctx;    # MT context object (unused)
-	if ($attr == NULL) $attr = $smartypants_attr;
-
-	if ($attr == 0) {
-		# do nothing;
-		return $text;
+		return $tokens;
 	}
 
-	$tokens;
-	$tokens = _TokenizeHTML($text);
-
-	$result = '';
-	$in_pre = 0;  # Keep track of when we're inside <pre> or <code> tags
-	foreach ($tokens as $cur_token) {
-		if ($cur_token[0] == "tag") {
-			# Don't mess with quotes inside tags
-			$result .= $cur_token[1];
-			if (preg_match("@$sp_tags_to_skip@", $cur_token[1], $matches)) {
-				$in_pre = isset($matches[1]) && $matches[1] == '/' ? 0 : 1;
-			}
-		} else {
-			$t = $cur_token[1];
-			if (! $in_pre) {
-				$t = ProcessEscapes($t);
-				$t = EducateEllipses($t);
-			}
-			$result .= $t;
-		}
-	}
-	return $result;
 }
-
-
-function EducateQuotes($_) {
-#
-#   Parameter:  String.
-#
-#   Returns:    The string, with "educated" curly quote HTML entities.
-#
-#   Example input:  "Isn't this fun?"
-#   Example output: &#8220;Isn&#8217;t this fun?&#8221;
-#
-	# Make our own "punctuation" character class, because the POSIX-style
-	# [:PUNCT:] is only available in Perl 5.6 or later:
-	$punct_class = "[!\"#\\$\\%'()*+,-.\\/:;<=>?\\@\\[\\\\\]\\^_`{|}~]";
-
-	# Special case if the very first character is a quote
-	# followed by punctuation at a non-word-break. Close the quotes by brute force:
-	$_ = preg_replace(
-		array("/^'(?=$punct_class\\B)/", "/^\"(?=$punct_class\\B)/"),
-		array('&#8217;',                 '&#8221;'), $_);
-
-
-	# Special case for double sets of quotes, e.g.:
-	#   <p>He said, "'Quoted' words in a larger quote."</p>
-	$_ = preg_replace(
-		array("/\"'(?=\w)/",    "/'\"(?=\w)/"),
-		array('&#8220;&#8216;', '&#8216;&#8220;'), $_);
-
-	# Special case for decade abbreviations (the '80s):
-	$_ = preg_replace("/'(?=\\d{2}s)/", '&#8217;', $_);
-
-	$close_class = '[^\ \t\r\n\[\{\(\-]';
-	$dec_dashes = '&\#8211;|&\#8212;';
-
-	# Get most opening single quotes:
-	$_ = preg_replace("{
-		(
-			\\s          |   # a whitespace char, or
-			&nbsp;      |   # a non-breaking space entity, or
-			--          |   # dashes, or
-			&[mn]dash;  |   # named dash entities
-			$dec_dashes |   # or decimal entities
-			&\\#x201[34];    # or hex
-		)
-		'                   # the quote
-		(?=\\w)              # followed by a word character
-		}x", '\1&#8216;', $_);
-	# Single closing quotes:
-	$_ = preg_replace("{
-		($close_class)?
-		'
-		(?(1)|          # If $1 captured, then do nothing;
-		  (?=\\s | s\\b)  # otherwise, positive lookahead for a whitespace
-		)               # char or an 's' at a word ending position. This
-						# is a special case to handle something like:
-						# \"<i>Custer</i>'s Last Stand.\"
-		}xi", '\1&#8217;', $_);
-
-	# Any remaining single quotes should be opening ones:
-	$_ = str_replace("'", '&#8216;', $_);
-
-
-	# Get most opening double quotes:
-	$_ = preg_replace("{
-		(
-			\\s          |   # a whitespace char, or
-			&nbsp;      |   # a non-breaking space entity, or
-			--          |   # dashes, or
-			&[mn]dash;  |   # named dash entities
-			$dec_dashes |   # or decimal entities
-			&\\#x201[34];    # or hex
-		)
-		\"                   # the quote
-		(?=\\w)              # followed by a word character
-		}x", '\1&#8220;', $_);
-
-	# Double closing quotes:
-	$_ = preg_replace("{
-		($close_class)?
-		\"
-		(?(1)|(?=\\s))   # If $1 captured, then do nothing;
-						   # if not, then make sure the next char is whitespace.
-		}x", '\1&#8221;', $_);
-
-	# Any remaining quotes should be opening ones.
-	$_ = str_replace('"', '&#8220;', $_);
-
-	return $_;
-}
-
-
-function EducateBackticks($_) {
-#
-#   Parameter:  String.
-#   Returns:    The string, with ``backticks'' -style double quotes
-#               translated into HTML curly quote entities.
-#
-#   Example input:  ``Isn't this fun?''
-#   Example output: &#8220;Isn't this fun?&#8221;
-#
-
-	$_ = str_replace(array("``",       "''",),
-					 array('&#8220;', '&#8221;'), $_);
-	return $_;
-}
-
-
-function EducateSingleBackticks($_) {
-#
-#   Parameter:  String.
-#   Returns:    The string, with `backticks' -style single quotes
-#               translated into HTML curly quote entities.
-#
-#   Example input:  `Isn't this fun?'
-#   Example output: &#8216;Isn&#8217;t this fun?&#8217;
-#
-
-	$_ = str_replace(array("`",       "'",),
-					 array('&#8216;', '&#8217;'), $_);
-	return $_;
-}
-
-
-function EducateDashes($_) {
-#
-#   Parameter:  String.
-#
-#   Returns:    The string, with each instance of "--" translated to
-#               an em-dash HTML entity.
-#
-
-	$_ = str_replace('--', '&#8212;', $_);
-	return $_;
-}
-
-
-function EducateDashesOldSchool($_) {
-#
-#   Parameter:  String.
-#
-#   Returns:    The string, with each instance of "--" translated to
-#               an en-dash HTML entity, and each "---" translated to
-#               an em-dash HTML entity.
-#
-
-	#                      em         en
-	$_ = str_replace(array("---",     "--",),
-					 array('&#8212;', '&#8211;'), $_);
-	return $_;
-}
-
-
-function EducateDashesOldSchoolInverted($_) {
-#
-#   Parameter:  String.
-#
-#   Returns:    The string, with each instance of "--" translated to
-#               an em-dash HTML entity, and each "---" translated to
-#               an en-dash HTML entity. Two reasons why: First, unlike the
-#               en- and em-dash syntax supported by
-#               EducateDashesOldSchool(), it's compatible with existing
-#               entries written before SmartyPants 1.1, back when "--" was
-#               only used for em-dashes.  Second, em-dashes are more
-#               common than en-dashes, and so it sort of makes sense that
-#               the shortcut should be shorter to type. (Thanks to Aaron
-#               Swartz for the idea.)
-#
-
-	#                      en         em
-	$_ = str_replace(array("---",     "--",),
-					 array('&#8211;', '&#8212;'), $_);
-	return $_;
-}
-
-
-function EducateEllipses($_) {
-#
-#   Parameter:  String.
-#   Returns:    The string, with each instance of "..." translated to
-#               an ellipsis HTML entity. Also converts the case where
-#               there are spaces between the dots.
-#
-#   Example input:  Huh...?
-#   Example output: Huh&#8230;?
-#
-
-	$_ = str_replace(array("...",     ". . .",), '&#8230;', $_);
-	return $_;
-}
-
-
-function StupefyEntities($_) {
-#
-#   Parameter:  String.
-#   Returns:    The string, with each SmartyPants HTML entity translated to
-#               its ASCII counterpart.
-#
-#   Example input:  &#8220;Hello &#8212; world.&#8221;
-#   Example output: "Hello -- world."
-#
-
-						#  en-dash    em-dash
-	$_ = str_replace(array('&#8211;', '&#8212;'),
-					 array('-',       '--'), $_);
-
-	# single quote         open       close
-	$_ = str_replace(array('&#8216;', '&#8217;'), "'", $_);
-
-	# double quote         open       close
-	$_ = str_replace(array('&#8220;', '&#8221;'), '"', $_);
-
-	$_ = str_replace('&#8230;', '...', $_); # ellipsis
-
-	return $_;
-}
-
-
-function ProcessEscapes($_) {
-#
-#   Parameter:  String.
-#   Returns:    The string, with after processing the following backslash
-#               escape sequences. This is useful if you want to force a "dumb"
-#               quote or other character to appear.
-#
-#               Escape  Value
-#               ------  -----
-#               \\      &#92;
-#               \"      &#34;
-#               \'      &#39;
-#               \.      &#46;
-#               \-      &#45;
-#               \`      &#96;
-#
-	$_ = str_replace(
-		array('\\\\',  '\"',    "\'",    '\.',    '\-',    '\`'),
-		array('&#92;', '&#34;', '&#39;', '&#46;', '&#45;', '&#96;'), $_);
-
-	return $_;
-}
-
-
-# _TokenizeHTML is shared between PHP SmartyPants and PHP Markdown.
-# We only define it if it is not already defined.
-if (!function_exists('_TokenizeHTML')) :
-function _TokenizeHTML($str) {
-#
-#   Parameter:  String containing HTML markup.
-#   Returns:    An array of the tokens comprising the input
-#               string. Each token is either a tag (possibly with nested,
-#               tags contained therein, such as <a href="<MTFoo>">, or a
-#               run of text between tags. Each element of the array is a
-#               two-element array; the first is either 'tag' or 'text';
-#               the second is the actual value.
-#
-#
-#   Regular expression derived from the _tokenize() subroutine in 
-#   Brad Choate's MTRegex plugin.
-#   <http://www.bradchoate.com/past/mtregex.php>
-#
-	$index = 0;
-	$tokens = array();
-
-	$match = '(?s:<!(?:--.*?--\s*)+>)|'.	# comment
-			 '(?s:<\?.*?\?>)|'.				# processing instruction
-			 								# regular tags
-			 '(?:<[/!$]?[-a-zA-Z0-9:]+\b(?>[^"\'>]+|"[^"]*"|\'[^\']*\')*>)'; 
-
-	$parts = preg_split("{($match)}", $str, -1, PREG_SPLIT_DELIM_CAPTURE);
-
-	foreach ($parts as $part) {
-		if (++$index % 2 && $part != '') 
-			$tokens[] = array('text', $part);
-		else
-			$tokens[] = array('tag', $part);
-	}
-	return $tokens;
-}
-endif;
 
 
 /*
@@ -754,6 +642,20 @@ proper HTML entity for closing single-quotes (`&#8217;`) by hand.
 Version History
 ---------------
 
+1.5.1f (23 Jan 2013)
+
+*	Fixed handling of HTML comments to match latest HTML specs instead of
+	doing it the old SGML way.
+
+*	Lowered WordPress filtering priority to avoid clashing with the 
+	[caption] tag filter. Thanks to Mehdi Kabab for the fix.
+
+
+1.5.1oo (19 May 2006, unreleased)
+
+*   Converted SmartyPants to a object-oriented design.
+
+
 1.5.1e (9 Dec 2005)
 
 *	Corrected a bug that prevented special characters from being 
@@ -802,11 +704,11 @@ Version History
 Author
 ------
 
-John Gruber
+Original SmartyPants by John Gruber
 <http://daringfireball.net/>
 
-Ported to PHP by Michel Fortin
-<http://www.michelf.com/>
+PHP Port by Michel Fortin
+<http://michelf.ca/>
 
 
 Additional Credits
@@ -817,7 +719,8 @@ Brad Choate also contributed a few bits of source code to this plug-in.
 Brad Choate is a fine hacker indeed. (<http://bradchoate.com/>)
 
 Jeremy Hedley (<http://antipixel.com/>) and Charles Wiltgen
-(<http://playbacktime.com/>) deserve mention for exemplary beta testing.
+(<http://playbacktime.com/>) deserve mention for exemplary beta testing of 
+the orignal SmartyPants.
 
 
 Copyright and License
@@ -827,8 +730,8 @@ Copyright (c) 2003 John Gruber
 <http://daringfireball.net/>  
 All rights reserved.
 
-Copyright (c) 2004-2005 Michel Fortin  
-<http://www.michelf.com>
+Copyright (c) 2004-2013 Michel Fortin  
+<http://michelf.ca>
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
- Updated the existing libraries to the latest versions:
  - Markdown: 1.0.1p from January 23, 2013
  - Smartypants: 1.5.1f from January 23, 2013

Added Markdown Extra so that decent code blocks are available. With
this, an extra option has been added to the configuration options
that lets you choose Extra.

Other updates include:
- dropping Wordpress specific information from both Markdown libs
- updated NOTICE with latest license information from Michel Fortin
